### PR TITLE
Allow QSpinBox lower than 0

### DIFF
--- a/src/m64py/frontend/plugin.py
+++ b/src/m64py/frontend/plugin.py
@@ -84,7 +84,8 @@ class Plugin(QDialog, Ui_PluginDialog):
                 row1 += 1
                 if not opts:
                     widget = QSpinBox()
-                    widget.setMaximum(65535)
+                    widget.setMaximum(32767)
+                    widget.setMinimum(-32767)
                     if param_help: widget.setToolTip(param_help)
                 else:
                     widget = QComboBox()


### PR DESCRIPTION
As of the config option merge in glide64mk2 we have to be able to set sub zero values in the QSpinBox in order to support the new game ini default
