### PR TITLE
UnicodeDecodeError corrected

### DIFF
--- a/src/m64py/core/core.py
+++ b/src/m64py/core/core.py
@@ -230,6 +230,8 @@ class Core:
                     plugin_handle, plugin_path, PLUGIN_NAME[plugin_type], plugin_desc, plugin_version)
         except OSError as e:
             log.debug("plugin_load_try()")
+            plugin_path = plugin_path.decode('ascii', 'ignore')
+            plugin_path = plugin_path.encode('ascii')
             log.error("failed to load plugin %s: %s" % (plugin_path, e))
 
     def plugin_startup(self, handle, name, desc):


### PR DESCRIPTION
I've got an UnicodeDecode error for ascii codec while logging a message and running m64py on Ubuntu 14.04+ versions. Adding two lines i could run the program well.

**Traceback (most recent call last):
  File "/usr/bin/m64py", line 83, in <module>
    main()
  File "/usr/bin/m64py", line 68, in main
    window = MainWindow((opts, args))
  File "/usr/share/m64py/m64py/frontend/mainwindow.py", line 87, in __init__
    self.worker.init()
  File "/usr/share/m64py/m64py/frontend/worker.py", line 56, in init
    self.plugins_load()
  File "/usr/share/m64py/m64py/frontend/worker.py", line 139, in plugins_load
    self.core.plugin_load_try(plugin_path)
  File "/usr/share/m64py/m64py/core/core.py", line 233, in plugin_load_try
    log.error("failed to load plugin %s: %s" % (plugin_path, e))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 32: ordinal not in range(128)**