### PR TITLE
Assign input values from button widget text

### DIFF
--- a/src/m64py/frontend/input.py
+++ b/src/m64py/frontend/input.py
@@ -328,6 +328,7 @@ class Input(QDialog, Ui_InputDialog):
                     v = "key(%s)" % value
                     self.config.set_parameter(key, v.encode())
                 else:
+		    self.config.set_parameter(key, widget.text().encode())
                     continue
 
     def get_axis(self, axis):


### PR DESCRIPTION
After assigning values with a joystick in the input plugin configuration window,
none of the joystick values were written to the config file because the code
assumed the value to be a key and wrote the parameter only if the key value was
successfully decoded. This sets the button parameters from the widget text if
the value could not be decoded as an sdl key and fixes the problem mentioned
in issue #2 regarding joysticks:

"I just installed and tried the latest release and I can confirm that it still
occurs, but only for USB controller inputs. That is: It will save my settings
if I assign keyboard keys to the N64 controller buttons, but not if I assign
USB controller buttons to N64 controller buttons. Those will revert to their
previous values as soon as I close the input configuration window."