### PR TITLE
Fixing 'Unhandled Exception' issue when closing input config dialog.

### DIFF
--- a/src/m64py/frontend/input.py
+++ b/src/m64py/frontend/input.py
@@ -241,7 +241,7 @@ class Input(QDialog, Ui_InputDialog):
     def save_opts(self):
         devicename = self.device_map.get(self.device)
         if devicename:
-            self.config.set_parameter("name", devicename.encode())
+            self.config.set_parameter("name", str(devicename).encode())
 
         for key, val in self.opts.items():
             param, tooltip, widget, ptype = val


### PR DESCRIPTION
Fixing issue #62 where closing the input dialog would cause an unhandled exception error.