### PR TITLE
Handle null tooltips in the input plugin view

### DIFF
--- a/src/m64py/frontend/input.py
+++ b/src/m64py/frontend/input.py
@@ -215,7 +215,10 @@ class Input(QDialog, Ui_InputDialog):
     def set_opts(self):
         for key, val in self.opts.items():
             param, tooltip, widget, ptype = val
-            tooltip = tooltip.decode()
+            if tooltip:
+                tooltip = tooltip.decode()
+            else:
+                tooltip = ""
             if ptype == M64TYPE_BOOL:
                 if param:
                     widget.setChecked(param)


### PR DESCRIPTION
When parsing the configuration in the input plugin view, check if the tooltip (derived from the m64p config file comments) is empty. 