### PR TITLE
Set correct resolution for high DPI displays (with vidext).

### DIFF
--- a/src/m64py/frontend/mainwindow.py
+++ b/src/m64py/frontend/mainwindow.py
@@ -133,7 +133,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
             ratio = self.devicePixelRatio()
             real_width = int(width * ratio)
-            real_height = int(width * ratio)
+            real_height = int(height * ratio)
 
             self.worker.core.config.open_section("Video-General")
             self.worker.core.config.set_parameter("ScreenWidth", real_width)

--- a/src/m64py/frontend/mainwindow.py
+++ b/src/m64py/frontend/mainwindow.py
@@ -131,14 +131,18 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                         bool(self.settings.get_int_safe("keep_aspect", 1)):
                     width, height = self.keep_aspect(size)
 
+            ratio = self.devicePixelRatio()
+            real_width = int(width * ratio)
+            real_height = int(width * ratio)
+
             self.worker.core.config.open_section("Video-General")
-            self.worker.core.config.set_parameter("ScreenWidth", width)
-            self.worker.core.config.set_parameter("ScreenHeight", height)
+            self.worker.core.config.set_parameter("ScreenWidth", real_width)
+            self.worker.core.config.set_parameter("ScreenHeight", real_height)
 
             if not fullscreen:
-                video_size = (width << 16) + height
+                video_size = (real_width << 16) + real_height
             else:
-                video_size = (width << 16) + (height + self.widgets_height)
+                video_size = (real_width << 16) + (real_height + self.widgets_height)
             if self.worker.state in (M64EMU_RUNNING, M64EMU_PAUSED):
                 self.worker.core_state_set(M64CORE_VIDEO_SIZE, video_size)
 

--- a/src/m64py/frontend/settings.py
+++ b/src/m64py/frontend/settings.py
@@ -312,8 +312,9 @@ class Settings(QDialog, Ui_Settings):
             self.set_section(combo, button, settings)
 
     def set_resolution(self):
-        width = self.core.config.get_parameter("ScreenWidth")
-        height = self.core.config.get_parameter("ScreenHeight")
+        ratio = self.parent.devicePixelRatio()
+        width = int(self.core.config.get_parameter("ScreenWidth") / ratio)
+        height = int(self.core.config.get_parameter("ScreenHeight") / ratio)
         if (width, height) not in MODES:
             MODES.append((width, height))
 
@@ -341,8 +342,9 @@ class Settings(QDialog, Ui_Settings):
             width, height = self.get_size_safe()
         else:
             width, height = self.comboResolution.currentText().split("x")
-        self.core.config.set_parameter("ScreenWidth", int(width))
-        self.core.config.set_parameter("ScreenHeight", int(height))
+        ratio = self.parent.devicePixelRatio()
+        self.core.config.set_parameter("ScreenWidth", int(int(width) * ratio))
+        self.core.config.set_parameter("ScreenHeight", int(int(height) * ratio))
         self.core.config.set_parameter("Fullscreen", self.checkFullscreen.isChecked())
         self.core.config.set_parameter("VerticalSync", self.checkVsync.isChecked())
         self.qset.setValue("keep_aspect", int(self.checkKeepAspect.isChecked()))


### PR DESCRIPTION
Resolution is still screwy in general for me (e.g. video is slightly too
high; window is resizable even though video plugin doesn't want it to
be...), but that happens regardless of whether I have high DPI enabled,
so it seems to be unrelated.

Not sure if this is the best way to do this.