### PR TITLE
WIP: Run the core on the main thread.

### DIFF
--- a/src/m64py/core/vidext.py
+++ b/src/m64py/core/vidext.py
@@ -24,6 +24,7 @@ except:
     glimport = False
 
 from PyQt5.QtOpenGL import QGLFormat
+from PyQt5.QtCore import QCoreApplication
 
 from sdl2 import SDL_WasInit, SDL_InitSubSystem, SDL_QuitSubSystem, SDL_INIT_VIDEO
 from sdl2 import SDL_GetNumDisplayModes, SDL_DisplayMode, SDL_GetDisplayMode
@@ -165,6 +166,7 @@ class Video():
         """Swaps the front/back buffers after
         rendering an output video frame. """
         self.widget.swapBuffers()
+        QCoreApplication.processEvents()
         return M64ERR_SUCCESS
 
     def resize_window(self, width, height):

--- a/src/m64py/frontend/mainwindow.py
+++ b/src/m64py/frontend/mainwindow.py
@@ -233,15 +233,20 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
     def on_file_open(self, filepath=None, filename=None):
         """Opens ROM file."""
+        if self.worker.is_stopping:
+            return
         if not filepath:
             action = self.sender()
             filepath = action.data()
         self.worker.core_state_query(M64CORE_EMU_STATE)
+        def after():
+            self.worker.set_filepath(filepath, filename)
+            self.worker.start()
+            self.raise_()
         if self.worker.state in [M64EMU_RUNNING, M64EMU_PAUSED]:
-            self.worker.stop()
-        self.worker.set_filepath(filepath, filename)
-        self.worker.start()
-        self.raise_()
+            self.worker.stop(and_then=after)
+        else:
+            after()
 
     def update_status(self, status):
         """Updates label in status bar."""

--- a/src/m64py/frontend/settings.py
+++ b/src/m64py/frontend/settings.py
@@ -103,8 +103,7 @@ class Settings(QDialog, Ui_Settings):
         self.parent.vidext = state
         self.comboResolution.setEnabled(not self.parent.vidext)
         self.checkFullscreen.setEnabled(not self.parent.vidext)
-        self.parent.worker.quit()
-        self.parent.worker.init()
+        self.parent.worker.quit(and_then=self.parent.worker.init)
 
     def connect_signals(self):
         self.browseLibrary.clicked.connect(lambda: self.browse_dialog(


### PR DESCRIPTION
(Instead of using a worker thread as is done currently.)

Why would you want to do that?  To fix no-vidext mode.

In mupen64plus-core, main_check_inputs calls SDL_PumpEvents.  SDL_PumpEvents checks if there is a SDL_VideoDevice active - which in this case is only be true when running without vidext - and if so, calls the video backend's PumpEvents.  On Mac, that's Cocoa_PumpEvents, which tries to pump the Cocoa event loop, which promptly crashes because you're only supposed to do that from the main thread.

According to the [SDL FAQ](https://wiki.libsdl.org/FAQDevelopment#Can_I_call_SDL_video_functions_from_multiple_threads.3F), it's not just SDL_PumpEvents that should be called on the main thread, but all video functions:

> Can I call SDL video functions from multiple threads?

> No, most graphics back ends are not thread-safe, so you should only call SDL video functions from the main thread of your application.

So to make this correct, the core's no-vidext code (that uses SDL video) would have to be modified to do everything asynchronously on the main thread.  I think that would be possible and nice to have, but in lieu of doing all the work for that, here's a patch to just run the core on the main thread.

I've verified on Mac that the UI is still usable while playing, in both vidext and no-vidext mode.  But I haven't tested this on other platforms at all.

Caveats:

- On Mac, opening a menu does its own "synchronous loop that pumps events" thing - it pumps events, but doesn't return to the code that sent it the menu-opened event until the menu is closed.  So opening a menu causes emulation to freeze.  While unintended, I'm not sure this behavior is actually undesirable, since the user probably opened the menu to select pause or stop anyway.  Still, it suggests this approach is not optimal in the long term, and there may be similar or worse side-effects on other platforms.

- In vidext mode, the script has the opportunity to call QCoreApplication.processEvents explicitly on each frame, but in no-vidext mode, it relies on the assumption that the core's SDL_PumpEvents also pumps Qt events, because they both run on top of the platform's native event loop.  This assumption is true on Mac, and my guess is that it's also true on other platforms, but I haven't tested it.  If it doesn't work somewhere, I guess the worker could be changed to support both modes, either running as a thread or borrowing the main thread.