### PR TITLE
Add hard-coded deadzone into input configuration buttons.

### DIFF
--- a/src/m64py/ui/inputbutton.py
+++ b/src/m64py/ui/inputbutton.py
@@ -100,6 +100,7 @@ class InputButton(QPushButton):
             self.clearFocus()
 
     def on_axis_value_changed(self, axis, value):
+        # SDL axes range from -32768 to 32767. Only map axes which are half-pressed or more.
         if abs(value) >= 16384:
             val = "-" if value < 0 else "+"
             self.on_joystick_event("axis", axis, val)

--- a/src/m64py/ui/inputbutton.py
+++ b/src/m64py/ui/inputbutton.py
@@ -100,8 +100,9 @@ class InputButton(QPushButton):
             self.clearFocus()
 
     def on_axis_value_changed(self, axis, value):
-        val = "-" if value < 0 else "+"
-        self.on_joystick_event("axis", axis, val)
+        if abs(value) >= 16384:
+            val = "-" if value < 0 else "+"
+            self.on_joystick_event("axis", axis, val)
 
     def on_button_value_changed(self, button, value):
         if value:


### PR DESCRIPTION
Works on my local build, and fixes #120.