### PR TITLE
Add fields to m64p_rom_settings

### DIFF
--- a/src/m64py/core/defs.py
+++ b/src/m64py/core/defs.py
@@ -190,7 +190,10 @@ class m64p_rom_settings(C.Structure):
         ('savetype', C.c_ubyte),
         ('status', C.c_ubyte),
         ('players', C.c_ubyte),
-        ('rumble', C.c_ubyte)
+        ('rumble', C.c_ubyte),
+        ('transferpak', C.c_ubyte),
+        ('mempak', C.c_ubyte),
+        ('biopak', C.c_ubyte)
     ]
 
 


### PR DESCRIPTION
The core library has added these fields so all frontends must be updated
or recompiled to continue working.  Otherwise the wrong size will be
sent to CoreGetRomSettings() and it will return a M64ERR_INPUT_INVALID
response.