### PR TITLE
Use ComboBox when key can be negative + fix slash problem

### DIFF
--- a/src/m64py/utils.py
+++ b/src/m64py/utils.py
@@ -71,10 +71,10 @@ def format_options(param_help):
     if not param_help:
         return None
     items = re.findall(
-        "(\d+|[\d,-]+)\s?=\s?([\w %-]+)", param_help)
+        "(\d+|[\d,-]+)\s?=\s?([\w/ %-]+)", param_help)
     for item in items:
         key, value = item
-        if '-' in key or ',' in key:
+        if '-' in key[1:] or ',' in key:
             return None
         else:
             opts[int(key)] = value


### PR DESCRIPTION
This turns many options in the glide64mk2 plugin from SpinBox into
ComboBox.  This commit also fixes an issue with the fps option not
showing "VI/s counter" correctly because it contains a slash.