### PR TITLE
Fix nosaveoptions

### DIFF
--- a/src/m64py/frontend/settings.py
+++ b/src/m64py/frontend/settings.py
@@ -273,15 +273,6 @@ class Settings(QDialog, Ui_Settings):
         self.checkDisableExtraMem.setToolTip(
             self.core.config.get_parameter_help("DisableExtraMem").decode())
 
-        delay_si = self.core.config.get_parameter("DelaySI")
-        if delay_si is not None:
-            self.checkDelaySI.setChecked(delay_si)
-        else:
-            self.checkDelaySI.setChecked(False)
-            self.checkDelaySI.setEnabled(False)
-        self.checkDelaySI.setToolTip(
-            self.core.config.get_parameter_help("DelaySI").decode())
-
         count_per_op = self.core.config.get_parameter("CountPerOp")
         if count_per_op is not None:
             self.comboCountPerOp.setCurrentIndex(count_per_op)
@@ -356,7 +347,6 @@ class Settings(QDialog, Ui_Settings):
         self.core.config.set_parameter("OnScreenDisplay", self.checkOSD.isChecked())
         self.core.config.set_parameter("NoCompiledJump", self.checkNoCompiledJump.isChecked())
         self.core.config.set_parameter("DisableExtraMem", self.checkDisableExtraMem.isChecked())
-        self.core.config.set_parameter("DelaySI", self.checkDelaySI.isChecked())
         self.core.config.set_parameter("CountPerOp", self.comboCountPerOp.currentIndex())
         self.core.config.set_parameter("SharedDataPath", self.pathData.text().encode())
 

--- a/src/m64py/frontend/worker.py
+++ b/src/m64py/frontend/worker.py
@@ -351,6 +351,10 @@ class Worker(QThread):
         self.rom_open()
         self.core.attach_plugins(
             self.get_plugins())
+        # Save the configuration file again, just in case a plugin has altered it.
+        # This is the last opportunity to save changes before the relatively
+        # long-running game.
+        self.core.config.save_file()
         self.core.execute()
         self.core.detach_plugins()
         self.rom_close()

--- a/src/m64py/ui/settings.ui
+++ b/src/m64py/ui/settings.ui
@@ -332,13 +332,6 @@ QGroupBox::title {
            </widget>
           </item>
           <item row="2" column="0">
-           <widget class="QCheckBox" name="checkDelaySI">
-            <property name="text">
-             <string>Delay SI</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
            <widget class="QComboBox" name="comboCountPerOp">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">


### PR DESCRIPTION
This adds additional configuration saving as discussed here:
https://github.com/mupen64plus/mupen64plus-audio-sdl/pull/26

Before that, though, I had to remove the DelaySI option, since that seems to now be gone from the core.

Thanks,
Corey