### PR TITLE
Fix requirement of pyqt5 to one that works.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pyqt5
+pyqt5==5.10.1
 pysdl2


### PR DESCRIPTION
## Description
- Put version for requiremnt pyqt `pyqt5==5.10.1`, in order to prevent error.
![image](https://user-images.githubusercontent.com/13908470/79049142-0ab59680-7bf8-11ea-9c0a-af313596b75b.png)
