### PR TITLE
Updating the command for modern Ubuntu versions (14.04 - 18.04 LTS)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Dependencies
 Ubuntu
 ++++++
 
-``sudo apt-get install python-pyqt5 pyqt5-dev-tools python-pyqt5.qtopengl
+``sudo apt install python3-pyqt5 pyqt5-dev-tools python3-pyqt5.qtopengl
 libsdl2-dev``
 
 PyPi


### PR DESCRIPTION
Similar to pull request #113 

m64py will install using python (provided you install `python-setuptools` too) but it won't run as it won't be able to find the module `sdl2`, part of `libsdl2-dev`.

Using `python3` (v3.6) instead of `python` (v2.7), m64py installs and runs normally.