### PR TITLE
Add support for multiple languages

### DIFF
--- a/bin/m64py
+++ b/bin/m64py
@@ -48,9 +48,10 @@ if __name__ == "__main__":
     app = QApplication(sys.argv)
     from m64py.opts import opts, args
 
+    i18n_directory = os.path.join(os.path.realpath(__file__)[:-10],"src","m64py","ui","i18n")
     locale = QLocale.system().name()
     translator = QTranslator()
-    if translator.load(":i18n/m64py_" + locale, ":/"):
+    if translator.load(os.path.join(i18n_directory,"m64py_" + locale + ".qm")):
         app.installTranslator(translator)
 
     sys.stderr.write("%s\nM64Py - A frontend for Mupen64Plus version %s\n\n" % (

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,10 @@ class BuildQt(setuptools.Command):
         with open(py_file, "w") as a_file:
             uic.compileUi(ui_file, a_file, from_imports=True)
 
+    def compile_ts(self, ts_file):
+        output_file = ts_file[:-3] + ".qm"
+        subprocess.call(["lconvert",ts_file,"-o",output_file])
+
     def run(self):
         basepath = os.path.join(os.path.dirname(__file__), "src", "m64py", "ui")
         for dirpath, _, filenames in os.walk(basepath):
@@ -67,6 +71,8 @@ class BuildQt(setuptools.Command):
                     self.compile_ui(os.path.join(dirpath, filename))
                 elif filename.endswith('.qrc'):
                     self.compile_rc(os.path.join(dirpath, filename))
+                elif filename.endswith('.ts'):
+                    self.compile_ts(os.path.join(dirpath, filename))
 
 
 class BuildDmg(setuptools.Command):


### PR DESCRIPTION
This PR does 2 things:

1. The old code for loading a qm file does not work. I replaced it with working code.
2. setup.py build will now convert ts to qm files.

Tested with #164 