### PR TITLE
Fixes #173 and #186: search for lrelease-qt5, ambiguous `python` invocation

### DIFF
--- a/bin/m64py
+++ b/bin/m64py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # Author: Milan Nikolic <gen2brain@gmail.com>

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,8 @@ class BuildQt(setuptools.Command):
         path = origpath.split(os.pathsep)
         path.append(os.path.dirname(PyQt5.__file__))
         os.putenv("PATH", os.pathsep.join(path))
-        if subprocess.call(["lrelease", ts_file, "-qm", qm_file]) > 0:
+        lr_exe = distutils.spawn.find_executable("lrelease") or distutils.spawn.find_executable("lrelease-qt5")
+        if subprocess.call([lr_exe, ts_file, "-qm", qm_file]) > 0:
             self.warn("Unable to compile translation file {}".format(qm_file))
             if not os.path.exists(qm_file):
                 sys.exit(1)


### PR DESCRIPTION
Primarily fixes for Fedora OS's binary naming conventions/linting.