### PR TITLE
Fixes/open rom from list

### DIFF
--- a/src/m64py/core/defs.py
+++ b/src/m64py/core/defs.py
@@ -196,7 +196,10 @@ class m64p_rom_settings(C.Structure):
         ('rumble', C.c_ubyte),
         ('transferpak', C.c_ubyte),
         ('mempak', C.c_ubyte),
-        ('biopak', C.c_ubyte)
+        ('biopak', C.c_ubyte),
+        ('disableextramem', C.c_ubyte),
+        ('countperop', C.c_uint),
+        ('sidmaduration', C.c_uint),
     ]
 
 


### PR DESCRIPTION
The "open rom from list" functionality wasn't working for me.  In particular, it wasn't listing any roms.  I updated the code to add roms to the list by searching the indicated rom directory recursively using `pathlib.Path.rglob`, and also made changes so roms would be added to the list even if the call to `core.get_rom_settings` returns `None` due to an error in the underlying core call.  It seems this is only used to get some useful name for the game, so in the event it's not found we just add it to the list anyways.

I also noticed that the defs was out of date, so I updated it.