### PR TITLE
Modify deps in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,9 +39,7 @@ Ubuntu
 ++++++
 
 
-``sudo apt install python3-pyqt5 python3-pyqt5.qtopengl``
-``sudo apt install pyqt5-dev-tools libsdl2-dev``
-``sudo apt install qttools5-dev-tools``
+``sudo apt install libsdl2-dev qttools5-dev-tools pyqt5-dev-tools python3-pyqt5 python3-pyqt5.qtopengl``
 
 PyPi
 ++++

--- a/README.rst
+++ b/README.rst
@@ -38,8 +38,10 @@ Dependencies
 Ubuntu
 ++++++
 
-``sudo apt install python3-pyqt5 pyqt5-dev-tools python3-pyqt5.qtopengl
-libsdl2-dev``
+
+``sudo apt install python3-pyqt5 python3-pyqt5.qtopengl``
+``sudo apt install pyqt5-dev-tools libsdl2-dev``
+``sudo apt install qttools5-dev-tools``
 
 PyPi
 ++++


### PR DESCRIPTION
Two minor changes to the README.

First, I grouped dependencies for system python3 libs versus system binary libs. The reason is I install this in a virtual environment, so I don't need sudo to install python packages. I've installed this multiple times and its a pain to separate the `python3-*` installs. This new format just lets me copy and paste the relevant parts.

Second, I found I also needed `qttools5-dev-tools`. So I documented this as well. 