### PR TITLE
Improve the search for lrelease in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ class BuildQt(setuptools.Command):
 
     def compile_ts(self, ts_file):
         import PyQt5
+        from PyQt5.QtCore import QLibraryInfo
         qm_file = os.path.splitext(ts_file)[0] + ".qm"
         if not distutils.dep_util.newer(ts_file, qm_file):
             return
@@ -68,7 +69,12 @@ class BuildQt(setuptools.Command):
         path = origpath.split(os.pathsep)
         path.append(os.path.dirname(PyQt5.__file__))
         os.putenv("PATH", os.pathsep.join(path))
-        lr_exe = distutils.spawn.find_executable("lrelease") or distutils.spawn.find_executable("lrelease-qt5")
+        lr_exe = QLibraryInfo.location(QLibraryInfo.LibraryLocation.BinariesPath)
+        if lr_exe:
+            lr_exe = os.path.join(lr_exe, "lrelease")
+            if not os.path.exists(lr_exe):
+                lr_exe = None
+        lr_exe = lr_exe or distutils.spawn.find_executable("lrelease") or distutils.spawn.find_executable("lrelease-qt5")
         if lr_exe is None:
             self.warn("Unable to find Qt's Linguist lrelease or lrelease-qt5 tools")
             sys.exit(1)


### PR DESCRIPTION
This fixes #225 by additionally searching for the `lrelease` binary in the location Qt installs its binaries to, since this location may not necessarily be in the environment's `PATH` variable. This allows the build script to more closely match how other build systems make use of tools like `lrelease`, and in particular mirrors how Qt's appropriate CMake module finds this program.

This change searches the Qt binary location first, and if it cannot find a file named `lrelease` there, or if for whatever reason an attempt to query the binary directory returns nothing, then setup.py will try finding a suitable binary exactly as it did before. I don't know if the old searching code is still necessary in this instance, so I kept it to be safe. This code only looks for `lrelease` in the Qt-provided location, and not `lrelease-qt5` like the path-based search does, since I assume the `-qt5` suffix wouldn't be used for binaries installed to the Qt5-specific directory.